### PR TITLE
Githubのユーザー検索・一覧表示のViewModelの実装

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -53,6 +53,7 @@ dependencies {
     implementation "androidx.compose.material:material-icons-extended:$compose_version"
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.1'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-compose:2.4.1'
     implementation 'androidx.activity:activity-compose:1.3.1'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'

--- a/app/src/main/java/com/example/learningandroidapp/ui/UserSearch.kt
+++ b/app/src/main/java/com/example/learningandroidapp/ui/UserSearch.kt
@@ -16,7 +16,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.learningandroidapp.ui.theme.LearningAndroidAppTheme
+import com.example.learningandroidapp.viewmodel.UserSearchViewModel
 
 
 @Preview
@@ -28,8 +30,11 @@ fun UserSearchScreenPreview() {
 }
 
 @Composable
-fun UserSearchScreen() {
-    val userList = List(12) { "ユーザー$it" }
+fun UserSearchScreen(viewModel: UserSearchViewModel = viewModel()) {
+    val uiState = viewModel.uiState
+    val searchUser = { text: String ->
+        viewModel.searchUser(text)
+    }
     Scaffold(
         topBar = {
             TopAppBar(
@@ -43,16 +48,15 @@ fun UserSearchScreen() {
         }
     ) {
         Column {
-            SearchBox()
-            UserList(userList = userList)
+            SearchBox(onSearch = searchUser)
+            UserList(userList = uiState.userList)
         }
     }
 }
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
-fun SearchBox(modifier: Modifier = Modifier) {
-    // TODO Stateの宣言位置を検討する
+fun SearchBox(modifier: Modifier = Modifier, onSearch: (String) -> Unit) {
     var text by remember {
         mutableStateOf("")
     }
@@ -85,7 +89,7 @@ fun SearchBox(modifier: Modifier = Modifier) {
                 keyboardController?.hide()
             })
         )
-        Button(modifier = Modifier.padding(end = 16.dp), onClick = { /*TODO*/ }) {
+        Button(modifier = Modifier.padding(end = 16.dp), onClick = { onSearch(text) }) {
             Text(text = "検索")
         }
     }

--- a/app/src/main/java/com/example/learningandroidapp/ui/UserSearch.kt
+++ b/app/src/main/java/com/example/learningandroidapp/ui/UserSearch.kt
@@ -49,7 +49,13 @@ fun UserSearchScreen(viewModel: UserSearchViewModel = viewModel()) {
     ) {
         Column {
             SearchBox(onSearch = searchUser)
-            UserList(userList = uiState.userList)
+            if (uiState.isLoading) {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator()
+                }
+            } else {
+                UserList(userList = uiState.userList)
+            }
         }
     }
 }
@@ -115,7 +121,7 @@ fun EmptyUserListPreview() {
 
 @Composable
 fun UserList(modifier: Modifier = Modifier, userList: List<String>) {
-    // TODO userList引数の型を再検討 + Loading表示
+    // TODO userList引数の型を再検討
     if (userList.isEmpty()) {
         Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
             Text(text = "検索結果なし", style = MaterialTheme.typography.subtitle1)

--- a/app/src/main/java/com/example/learningandroidapp/ui/UserSearch.kt
+++ b/app/src/main/java/com/example/learningandroidapp/ui/UserSearch.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.learningandroidapp.R
 import com.example.learningandroidapp.ui.theme.LearningAndroidAppTheme
+import com.example.learningandroidapp.viewmodel.UserSearchUiState
 import com.example.learningandroidapp.viewmodel.UserSearchViewModel
 
 
@@ -50,13 +51,28 @@ fun UserSearchScreen(viewModel: UserSearchViewModel = viewModel()) {
     ) {
         Column {
             SearchBox(onSearch = searchUser)
-            if (uiState.isLoading) {
-                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                    CircularProgressIndicator()
-                }
-            } else {
-                UserList(userList = uiState.userList)
-            }
+            UserSearchContent(uiState = uiState)
+        }
+    }
+}
+
+@Composable
+fun UserSearchContent(uiState: UserSearchUiState) {
+    if (uiState.isLoading) {
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            CircularProgressIndicator()
+        }
+    } else {
+        UserList(userList = uiState.userList)
+    }
+}
+
+@Preview
+@Composable
+fun UserSearchContentLoadingPreview() {
+    LearningAndroidAppTheme {
+        Surface {
+            UserSearchContent(uiState = UserSearchUiState(isLoading = true))
         }
     }
 }

--- a/app/src/main/java/com/example/learningandroidapp/viewmodel/UserSearchViewModel.kt
+++ b/app/src/main/java/com/example/learningandroidapp/viewmodel/UserSearchViewModel.kt
@@ -1,0 +1,21 @@
+package com.example.learningandroidapp.viewmodel
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+
+
+data class UserSearchUiState(
+    val userList: List<String> = emptyList(),
+    val isLoading: Boolean = false
+)
+
+class UserSearchViewModel : ViewModel() {
+    var uiState by mutableStateOf(UserSearchUiState())
+        private set
+
+    fun searchUser(text: String) {
+        // TODO call API(repository)
+    }
+}


### PR DESCRIPTION
### 変更点
- UserSearchViewModelを追加
  - 検索結果と検索処理を呼び出す
- UserSearchViewModelをUIから使用するように変更
  - それに伴って幾つかのComposableの引数を変更
- UserSearchUiStateを追加
- loading画面を追加
  - それに伴ってUserSearchContentを追加