### PR TITLE
Githubのユーザー検索・一覧表示のAPI実装

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,6 +17,13 @@ android {
         vectorDrawables {
             useSupportLibrary true
         }
+
+        defaultConfig {
+            def properties = new Properties()
+            properties.load(project.file('local.properties').newDataInputStream())
+            def GITHUB_TOKEN = properties.getProperty("GITHUB_TOKEN")
+            buildConfigField("String", "GITHUB_TOKEN", "\"${GITHUB_TOKEN}\"")
+        }
     }
 
     buildTypes {
@@ -55,6 +62,8 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.1'
     implementation 'androidx.lifecycle:lifecycle-viewmodel-compose:2.4.1'
     implementation 'androidx.activity:activity-compose:1.3.1'
+    implementation 'com.squareup.retrofit2:retrofit:2.9.0'
+    implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.example.learningandroidapp">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/java/com/example/learningandroidapp/api/GitHubApiService.kt
+++ b/app/src/main/java/com/example/learningandroidapp/api/GitHubApiService.kt
@@ -7,6 +7,7 @@ import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import retrofit2.http.GET
 import retrofit2.http.Headers
+import retrofit2.http.Query
 
 private val gson = GsonBuilder()
     .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
@@ -29,7 +30,7 @@ interface GitHubApiService {
         "Accept: application/vnd.github+json"
     )
     @GET("search/users")
-    suspend fun getUsers(text: String): GetUsersResponse
+    suspend fun getUsers(@Query("q") query: String): GetUsersResponse
 
 }
 

--- a/app/src/main/java/com/example/learningandroidapp/api/GitHubApiService.kt
+++ b/app/src/main/java/com/example/learningandroidapp/api/GitHubApiService.kt
@@ -1,0 +1,40 @@
+package com.example.learningandroidapp.api
+
+import com.example.learningandroidapp.BuildConfig
+import com.google.gson.FieldNamingPolicy
+import com.google.gson.GsonBuilder
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.http.GET
+import retrofit2.http.Headers
+
+private val gson = GsonBuilder()
+    .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+    .create()
+private const val BASE_URL = "https://api.github.com"
+private val retrofit = Retrofit.Builder()
+    .addConverterFactory(GsonConverterFactory.create(gson))
+    .baseUrl(BASE_URL)
+    .build()
+
+data class GetUsersResponse(
+    val totalCount: Int,
+    val incompleteResults: Boolean,
+    val items: List<User>
+)
+
+interface GitHubApiService {
+    @Headers(
+        "Authorization: token ${BuildConfig.GITHUB_TOKEN}",
+        "Accept: application/vnd.github+json"
+    )
+    @GET("search/users")
+    suspend fun getUsers(text: String): GetUsersResponse
+
+}
+
+object GitHubApi {
+    val retrofitService: GitHubApiService by lazy {
+        retrofit.create(GitHubApiService::class.java)
+    }
+}

--- a/app/src/main/java/com/example/learningandroidapp/api/User.kt
+++ b/app/src/main/java/com/example/learningandroidapp/api/User.kt
@@ -1,0 +1,6 @@
+package com.example.learningandroidapp.api
+
+data class User(
+    val avatarUrl: String,
+    val login: String
+)

--- a/app/src/main/java/com/example/learningandroidapp/viewmodel/UserSearchViewModel.kt
+++ b/app/src/main/java/com/example/learningandroidapp/viewmodel/UserSearchViewModel.kt
@@ -4,6 +4,9 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.learningandroidapp.api.GitHubApi
+import kotlinx.coroutines.launch
 
 
 data class UserSearchUiState(
@@ -16,6 +19,13 @@ class UserSearchViewModel : ViewModel() {
         private set
 
     fun searchUser(text: String) {
-        // TODO call API(repository)
+        uiState = uiState.copy(isLoading = true)
+        viewModelScope.launch {
+            // TODO repository経由で呼ぶように変更する
+            val result = GitHubApi.retrofitService.getUsers(text)
+            val items = result.items
+            val usernames = items.map { it.login }
+            uiState = uiState.copy(isLoading = false, userList = usernames)
+        }
     }
 }


### PR DESCRIPTION
### 概要
- GitHubのユーザー検索・一覧表示のページ実装
  - API(`https://api.github.com/search/users`)を用いてユーザーを検索

### 変更点
- retrofit2, retrofit2:converter-gsonを依存関係に追加
- app/local.propertiesから`GITHUB_TOKEN`を読み込んでbuildConfigFieldにセット
- GitHubApiServiceでユーザーを検索するAPIを叩くように実装
- 一度ViewModelでAPIを直接呼び出すように実装
  - 後でRepositoryを実装する際にRepository経由でAPIを呼び出すように修正