### PR TITLE
Githubのユーザー検索・一覧表示のRepository実装

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,8 @@
 plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
+    id 'kotlin-kapt'
+    id 'dagger.hilt.android.plugin'
 }
 
 android {
@@ -64,6 +66,8 @@ dependencies {
     implementation 'androidx.activity:activity-compose:1.3.1'
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'
     implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
+    implementation "com.google.dagger:hilt-android:$hilt_version"
+    kapt "com.google.dagger:hilt-android-compiler:$hilt_version"
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -64,6 +64,7 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.1'
     implementation 'androidx.lifecycle:lifecycle-viewmodel-compose:2.4.1'
     implementation 'androidx.activity:activity-compose:1.3.1'
+    implementation "io.coil-kt:coil-compose:2.1.0"
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'
     implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
     implementation "com.google.dagger:hilt-android:$hilt_version"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.LearningAndroidApp"
+        android:name=".LearningAndroidApp"
         tools:targetApi="31">
         <activity
             android:name=".MainActivity"

--- a/app/src/main/java/com/example/learningandroidapp/LearningAndroidApp.kt
+++ b/app/src/main/java/com/example/learningandroidapp/LearningAndroidApp.kt
@@ -1,0 +1,8 @@
+package com.example.learningandroidapp
+
+import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
+
+
+@HiltAndroidApp
+class LearningAndroidApp : Application()

--- a/app/src/main/java/com/example/learningandroidapp/MainActivity.kt
+++ b/app/src/main/java/com/example/learningandroidapp/MainActivity.kt
@@ -5,7 +5,9 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import com.example.learningandroidapp.ui.UserSearchScreen
 import com.example.learningandroidapp.ui.theme.LearningAndroidAppTheme
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/example/learningandroidapp/api/GetUsersResponse.kt
+++ b/app/src/main/java/com/example/learningandroidapp/api/GetUsersResponse.kt
@@ -1,0 +1,7 @@
+package com.example.learningandroidapp.api
+
+data class GetUsersResponse(
+    val totalCount: Int,
+    val incompleteResults: Boolean,
+    val items: List<UserApiModel>
+)

--- a/app/src/main/java/com/example/learningandroidapp/api/GitHubApiService.kt
+++ b/app/src/main/java/com/example/learningandroidapp/api/GitHubApiService.kt
@@ -5,8 +5,6 @@ import retrofit2.http.GET
 import retrofit2.http.Headers
 import retrofit2.http.Query
 
-const val BASE_URL = "https://api.github.com"
-
 data class GetUsersResponse(
     val totalCount: Int,
     val incompleteResults: Boolean,

--- a/app/src/main/java/com/example/learningandroidapp/api/GitHubApiService.kt
+++ b/app/src/main/java/com/example/learningandroidapp/api/GitHubApiService.kt
@@ -1,27 +1,16 @@
 package com.example.learningandroidapp.api
 
 import com.example.learningandroidapp.BuildConfig
-import com.google.gson.FieldNamingPolicy
-import com.google.gson.GsonBuilder
-import retrofit2.Retrofit
-import retrofit2.converter.gson.GsonConverterFactory
 import retrofit2.http.GET
 import retrofit2.http.Headers
 import retrofit2.http.Query
 
-private val gson = GsonBuilder()
-    .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
-    .create()
-private const val BASE_URL = "https://api.github.com"
-private val retrofit = Retrofit.Builder()
-    .addConverterFactory(GsonConverterFactory.create(gson))
-    .baseUrl(BASE_URL)
-    .build()
+const val BASE_URL = "https://api.github.com"
 
 data class GetUsersResponse(
     val totalCount: Int,
     val incompleteResults: Boolean,
-    val items: List<User>
+    val items: List<UserApiModel>
 )
 
 interface GitHubApiService {
@@ -32,10 +21,4 @@ interface GitHubApiService {
     @GET("search/users")
     suspend fun getUsers(@Query("q") query: String): GetUsersResponse
 
-}
-
-object GitHubApi {
-    val retrofitService: GitHubApiService by lazy {
-        retrofit.create(GitHubApiService::class.java)
-    }
 }

--- a/app/src/main/java/com/example/learningandroidapp/api/GitHubApiService.kt
+++ b/app/src/main/java/com/example/learningandroidapp/api/GitHubApiService.kt
@@ -5,12 +5,6 @@ import retrofit2.http.GET
 import retrofit2.http.Headers
 import retrofit2.http.Query
 
-data class GetUsersResponse(
-    val totalCount: Int,
-    val incompleteResults: Boolean,
-    val items: List<UserApiModel>
-)
-
 interface GitHubApiService {
     @Headers(
         "Authorization: token ${BuildConfig.GITHUB_TOKEN}",

--- a/app/src/main/java/com/example/learningandroidapp/api/UserApiModel.kt
+++ b/app/src/main/java/com/example/learningandroidapp/api/UserApiModel.kt
@@ -1,6 +1,6 @@
 package com.example.learningandroidapp.api
 
-data class User(
+data class UserApiModel(
     val avatarUrl: String,
     val login: String
 )

--- a/app/src/main/java/com/example/learningandroidapp/di/ApiModule.kt
+++ b/app/src/main/java/com/example/learningandroidapp/di/ApiModule.kt
@@ -1,6 +1,5 @@
 package com.example.learningandroidapp.di
 
-import com.example.learningandroidapp.api.BASE_URL
 import com.example.learningandroidapp.api.GitHubApiService
 import com.google.gson.FieldNamingPolicy
 import com.google.gson.Gson
@@ -12,6 +11,8 @@ import dagger.hilt.components.SingletonComponent
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import javax.inject.Singleton
+
+private const val BASE_URL = "https://api.github.com"
 
 @Module
 @InstallIn(SingletonComponent::class)

--- a/app/src/main/java/com/example/learningandroidapp/di/ApiModule.kt
+++ b/app/src/main/java/com/example/learningandroidapp/di/ApiModule.kt
@@ -1,4 +1,42 @@
 package com.example.learningandroidapp.di
 
+import com.example.learningandroidapp.api.BASE_URL
+import com.example.learningandroidapp.api.GitHubApiService
+import com.google.gson.FieldNamingPolicy
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
 object ApiModule {
+
+    @Provides
+    @Singleton
+    fun provideGson(): Gson {
+        return GsonBuilder()
+            .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+            .create()
+    }
+
+    @Provides
+    @Singleton
+    fun provideRetrofit(gson: Gson): Retrofit {
+        return Retrofit.Builder()
+            .addConverterFactory(GsonConverterFactory.create(gson))
+            .baseUrl(BASE_URL)
+            .build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideGitHubApi(retrofit: Retrofit): GitHubApiService {
+        return retrofit.create(GitHubApiService::class.java)
+    }
 }

--- a/app/src/main/java/com/example/learningandroidapp/di/ApiModule.kt
+++ b/app/src/main/java/com/example/learningandroidapp/di/ApiModule.kt
@@ -1,0 +1,4 @@
+package com.example.learningandroidapp.di
+
+object ApiModule {
+}

--- a/app/src/main/java/com/example/learningandroidapp/di/RepositoryModule.kt
+++ b/app/src/main/java/com/example/learningandroidapp/di/RepositoryModule.kt
@@ -9,7 +9,7 @@ import dagger.hilt.components.SingletonComponent
 
 @Module
 @InstallIn(SingletonComponent::class)
-abstract class UserRepositoryModule {
+abstract class RepositoryModule {
     @Binds
     abstract fun bindUserRepository(impl: UserRepositoryImpl): UserRepository
 }

--- a/app/src/main/java/com/example/learningandroidapp/di/UserRepositoryModule.kt
+++ b/app/src/main/java/com/example/learningandroidapp/di/UserRepositoryModule.kt
@@ -1,0 +1,15 @@
+package com.example.learningandroidapp.di
+
+import com.example.learningandroidapp.repository.UserRepository
+import com.example.learningandroidapp.repository.UserRepositoryImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class UserRepositoryModule {
+    @Binds
+    abstract fun bindUserRepository(impl: UserRepositoryImpl): UserRepository
+}

--- a/app/src/main/java/com/example/learningandroidapp/models/User.kt
+++ b/app/src/main/java/com/example/learningandroidapp/models/User.kt
@@ -1,3 +1,6 @@
 package com.example.learningandroidapp.models
 
-data class User()
+data class User(
+    val avatarUrl: String,
+    val userName: String
+)

--- a/app/src/main/java/com/example/learningandroidapp/models/User.kt
+++ b/app/src/main/java/com/example/learningandroidapp/models/User.kt
@@ -1,0 +1,3 @@
+package com.example.learningandroidapp.models
+
+data class User()

--- a/app/src/main/java/com/example/learningandroidapp/repository/UserRepository.kt
+++ b/app/src/main/java/com/example/learningandroidapp/repository/UserRepository.kt
@@ -1,0 +1,23 @@
+package com.example.learningandroidapp.repository
+
+import com.example.learningandroidapp.api.GitHubApiService
+import com.example.learningandroidapp.models.User
+import javax.inject.Inject
+import javax.inject.Singleton
+
+
+@Singleton
+class UserRepository @Inject constructor(
+    private val gitHubApi: GitHubApiService
+) {
+    suspend fun getUserList(text: String): List<User> {
+        val response = gitHubApi.getUsers(text)
+        val userList = response.items.map {
+            User(
+                userName = it.login,
+                avatarUrl = it.avatarUrl
+            )
+        }
+        return userList
+    }
+}

--- a/app/src/main/java/com/example/learningandroidapp/repository/UserRepository.kt
+++ b/app/src/main/java/com/example/learningandroidapp/repository/UserRepository.kt
@@ -1,23 +1,8 @@
 package com.example.learningandroidapp.repository
 
-import com.example.learningandroidapp.api.GitHubApiService
 import com.example.learningandroidapp.models.User
-import javax.inject.Inject
-import javax.inject.Singleton
 
 
-@Singleton
-class UserRepository @Inject constructor(
-    private val gitHubApi: GitHubApiService
-) {
-    suspend fun getUserList(text: String): List<User> {
-        val response = gitHubApi.getUsers(text)
-        val userList = response.items.map {
-            User(
-                userName = it.login,
-                avatarUrl = it.avatarUrl
-            )
-        }
-        return userList
-    }
+interface UserRepository {
+    suspend fun getUserList(text: String): List<User>
 }

--- a/app/src/main/java/com/example/learningandroidapp/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/example/learningandroidapp/repository/UserRepositoryImpl.kt
@@ -1,0 +1,23 @@
+package com.example.learningandroidapp.repository
+
+import com.example.learningandroidapp.api.GitHubApiService
+import com.example.learningandroidapp.models.User
+import javax.inject.Inject
+import javax.inject.Singleton
+
+
+@Singleton
+class UserRepositoryImpl @Inject constructor(
+    private val gitHubApi: GitHubApiService
+) : UserRepository {
+    override suspend fun getUserList(text: String): List<User> {
+        val response = gitHubApi.getUsers(text)
+        val userList = response.items.map {
+            User(
+                userName = it.login,
+                avatarUrl = it.avatarUrl
+            )
+        }
+        return userList
+    }
+}

--- a/app/src/main/java/com/example/learningandroidapp/ui/UserSearch.kt
+++ b/app/src/main/java/com/example/learningandroidapp/ui/UserSearch.kt
@@ -146,7 +146,6 @@ fun EmptyUserListPreview() {
 
 @Composable
 fun UserList(modifier: Modifier = Modifier, userList: List<User>) {
-    // TODO userList引数の型を再検討
     if (userList.isEmpty()) {
         Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
             Text(

--- a/app/src/main/java/com/example/learningandroidapp/ui/UserSearch.kt
+++ b/app/src/main/java/com/example/learningandroidapp/ui/UserSearch.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.learningandroidapp.R
+import com.example.learningandroidapp.models.User
 import com.example.learningandroidapp.ui.theme.LearningAndroidAppTheme
 import com.example.learningandroidapp.viewmodel.UserSearchUiState
 import com.example.learningandroidapp.viewmodel.UserSearchViewModel
@@ -120,7 +121,9 @@ fun SearchBox(modifier: Modifier = Modifier, onSearch: (String) -> Unit) {
 @Preview
 @Composable
 fun UserListPreview() {
-    val userList = List(12) { "ユーザー$it" }
+    val userList = List(12) {
+        User(userName = "ユーザー$it", avatarUrl = "")
+    }
     LearningAndroidAppTheme {
         Surface {
             UserList(userList = userList)
@@ -131,7 +134,9 @@ fun UserListPreview() {
 @Preview
 @Composable
 fun EmptyUserListPreview() {
-    val userList = List(0) { "ユーザー$it" }
+    val userList = List(0) {
+        User(userName = "ユーザー$it", avatarUrl = "")
+    }
     LearningAndroidAppTheme {
         Surface {
             UserList(userList = userList)
@@ -140,7 +145,7 @@ fun EmptyUserListPreview() {
 }
 
 @Composable
-fun UserList(modifier: Modifier = Modifier, userList: List<String>) {
+fun UserList(modifier: Modifier = Modifier, userList: List<User>) {
     // TODO userList引数の型を再検討
     if (userList.isEmpty()) {
         Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
@@ -159,7 +164,7 @@ fun UserList(modifier: Modifier = Modifier, userList: List<String>) {
 }
 
 @Composable
-fun UserListItem(modifier: Modifier = Modifier, user: String) {
+fun UserListItem(modifier: Modifier = Modifier, user: User) {
     Row(
         modifier = modifier
             .fillMaxWidth()
@@ -176,6 +181,6 @@ fun UserListItem(modifier: Modifier = Modifier, user: String) {
         ) {
             Text(text = "TODO")
         }
-        Text(modifier = Modifier.padding(start = 16.dp), text = user)
+        Text(modifier = Modifier.padding(start = 16.dp), text = user.userName)
     }
 }

--- a/app/src/main/java/com/example/learningandroidapp/ui/UserSearch.kt
+++ b/app/src/main/java/com/example/learningandroidapp/ui/UserSearch.kt
@@ -13,12 +13,14 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import coil.compose.AsyncImage
 import com.example.learningandroidapp.R
 import com.example.learningandroidapp.models.User
 import com.example.learningandroidapp.ui.theme.LearningAndroidAppTheme
@@ -187,15 +189,14 @@ fun UserListItem(modifier: Modifier = Modifier, user: User) {
             .padding(top = 8.dp, bottom = 8.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Surface(
+        AsyncImage(
+            model = user.avatarUrl,
+            contentDescription = "avatar",
             modifier = Modifier
                 .padding(start = 16.dp)
-                .size(56.dp),
-            color = MaterialTheme.colors.primary,
-            shape = CircleShape,
-        ) {
-            Text(text = "TODO")
-        }
+                .size(56.dp)
+                .clip(CircleShape)
+        )
         Text(modifier = Modifier.padding(start = 16.dp), text = user.userName)
     }
 }

--- a/app/src/main/java/com/example/learningandroidapp/ui/UserSearch.kt
+++ b/app/src/main/java/com/example/learningandroidapp/ui/UserSearch.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -34,12 +35,27 @@ fun UserSearchScreenPreview() {
 }
 
 @Composable
-fun UserSearchScreen(viewModel: UserSearchViewModel = viewModel()) {
+fun UserSearchScreen(
+    viewModel: UserSearchViewModel = viewModel(),
+    scaffoldState: ScaffoldState = rememberScaffoldState()
+) {
     val uiState = viewModel.uiState
     val searchUser = { text: String ->
         viewModel.searchUser(text)
     }
+
+    if (uiState.hasError) {
+        val context = LocalContext.current
+        LaunchedEffect(scaffoldState.snackbarHostState) {
+            scaffoldState.snackbarHostState.showSnackbar(
+                message = context.getString(R.string.network_error_message)
+            )
+            viewModel.errorMessageShown()
+        }
+    }
+
     Scaffold(
+        scaffoldState = scaffoldState,
         topBar = {
             TopAppBar(
                 title = {

--- a/app/src/main/java/com/example/learningandroidapp/viewmodel/UserSearchViewModel.kt
+++ b/app/src/main/java/com/example/learningandroidapp/viewmodel/UserSearchViewModel.kt
@@ -14,7 +14,8 @@ import javax.inject.Inject
 
 data class UserSearchUiState(
     val userList: List<User> = emptyList(),
-    val isLoading: Boolean = false
+    val isLoading: Boolean = false,
+    val hasError: Boolean = false,
 )
 
 @HiltViewModel
@@ -27,8 +28,16 @@ class UserSearchViewModel @Inject constructor(
     fun searchUser(text: String) {
         uiState = uiState.copy(isLoading = true)
         viewModelScope.launch {
-            val userList = userRepository.getUserList(text)
-            uiState = uiState.copy(isLoading = false, userList = userList)
+            uiState = try {
+                val userList = userRepository.getUserList(text)
+                uiState.copy(isLoading = false, userList = userList)
+            } catch (e: Exception) {
+                uiState.copy(isLoading = false, hasError = true, userList = emptyList())
+            }
         }
+    }
+
+    fun errorMessageShown() {
+        uiState = uiState.copy(hasError = false)
     }
 }

--- a/app/src/main/java/com/example/learningandroidapp/viewmodel/UserSearchViewModel.kt
+++ b/app/src/main/java/com/example/learningandroidapp/viewmodel/UserSearchViewModel.kt
@@ -5,27 +5,30 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.learningandroidapp.api.GitHubApi
+import com.example.learningandroidapp.models.User
+import com.example.learningandroidapp.repository.UserRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 
 data class UserSearchUiState(
-    val userList: List<String> = emptyList(),
+    val userList: List<User> = emptyList(),
     val isLoading: Boolean = false
 )
 
-class UserSearchViewModel : ViewModel() {
+@HiltViewModel
+class UserSearchViewModel @Inject constructor(
+    private val userRepository: UserRepository
+) : ViewModel() {
     var uiState by mutableStateOf(UserSearchUiState())
         private set
 
     fun searchUser(text: String) {
         uiState = uiState.copy(isLoading = true)
         viewModelScope.launch {
-            // TODO repository経由で呼ぶように変更する
-            val result = GitHubApi.retrofitService.getUsers(text)
-            val items = result.items
-            val usernames = items.map { it.login }
-            uiState = uiState.copy(isLoading = false, userList = usernames)
+            val userList = userRepository.getUserList(text)
+            uiState = uiState.copy(isLoading = false, userList = userList)
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,4 +5,5 @@
     <string name="searchbox_clear_button_text">clear text</string>
     <string name="userlist_empty_text">検索結果なし</string>
     <string name="searchbox_button_text">検索</string>
+    <string name="network_error_message">通信に失敗しました。再度お試しください。</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,10 @@
 buildscript {
     ext {
         compose_version = '1.1.0-beta01'
+        hilt_version = '2.42'
+    }
+    dependencies {
+        classpath "com.google.dagger:hilt-android-gradle-plugin:$hilt_version"
     }
 }// Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {


### PR DESCRIPTION
### 概要
- Githubのユーザー検索・一覧表示の作成
  - APIから取得する部分をRepositoryを用いて抽象化
  - Userデータのモデル定義
### 変更点
- Hiltの導入
- repository/UserRepositoryをinterfaceで定義
  - 実装はrepository/UserRepositoryImpl
- diディレクトリでAPIとRepositoryのModuleを実装
- APIから返されるUserデータの定義をUserApiModelに変更
- ViewModelなどで使用するUserデータを新たにmodels/Userに定義
  - UserRepositoryは新たに定義したUserを返す
  - ViewModel, UIで新たに定義したUserを使用するように変更
-  通信エラー時にスナックバーでメッセージを表示するように変更
- avatar画像が設定されるように変更
  - coil-composeを導入