### PR TITLE
ユーザー検索画面のテストコードを実装

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -75,4 +75,11 @@ dependencies {
     androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"
     debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
     debugImplementation "androidx.compose.ui:ui-test-manifest:$compose_version"
+
+    // Kotest
+    testImplementation 'io.kotest:kotest-runner-junit5:5.3.2'
+    testImplementation 'io.kotest:kotest-assertions-core:5.3.2'
+
+    // Mockk
+    testImplementation "io.mockk:mockk:1.12.4"
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,6 +52,11 @@ android {
             excludes += '/META-INF/{AL2.0,LGPL2.1}'
         }
     }
+    testOptions {
+        unitTests.all {
+            useJUnitPlatform()
+        }
+    }
 }
 
 dependencies {

--- a/app/src/main/java/com/example/learningandroidapp/repository/UserRepository.kt
+++ b/app/src/main/java/com/example/learningandroidapp/repository/UserRepository.kt
@@ -4,5 +4,5 @@ import com.example.learningandroidapp.models.User
 
 
 interface UserRepository {
-    suspend fun getUserList(text: String): List<User>
+    suspend fun getUserList(userName: String): List<User>
 }

--- a/app/src/main/java/com/example/learningandroidapp/repository/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/example/learningandroidapp/repository/UserRepositoryImpl.kt
@@ -10,8 +10,8 @@ import javax.inject.Singleton
 class UserRepositoryImpl @Inject constructor(
     private val gitHubApi: GitHubApiService
 ) : UserRepository {
-    override suspend fun getUserList(text: String): List<User> {
-        val response = gitHubApi.getUsers(text)
+    override suspend fun getUserList(userName: String): List<User> {
+        val response = gitHubApi.getUsers(userName)
         val userList = response.items.map {
             User(
                 userName = it.login,

--- a/app/src/main/java/com/example/learningandroidapp/ui/UserSearch.kt
+++ b/app/src/main/java/com/example/learningandroidapp/ui/UserSearch.kt
@@ -42,8 +42,11 @@ fun UserSearchScreen(
     scaffoldState: ScaffoldState = rememberScaffoldState()
 ) {
     val uiState = viewModel.uiState
-    val searchUser = { text: String ->
-        viewModel.searchUser(text)
+    val onUserNameChanged = { userName: String ->
+        viewModel.onUserNameChanged(userName)
+    }
+    val searchUser = {
+        viewModel.searchUser()
     }
 
     if (uiState.hasError) {
@@ -69,7 +72,11 @@ fun UserSearchScreen(
         }
     ) {
         Column {
-            SearchBox(onSearch = searchUser)
+            SearchBox(
+                userName = uiState.userName,
+                onTextChanged = onUserNameChanged,
+                onSearch = searchUser
+            )
             UserSearchContent(uiState = uiState)
         }
     }
@@ -98,26 +105,25 @@ fun UserSearchContentLoadingPreview() {
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
-fun SearchBox(modifier: Modifier = Modifier, onSearch: (String) -> Unit) {
-    var text by remember {
-        mutableStateOf("")
-    }
-    val isEmpty by remember {
-        derivedStateOf { text.isEmpty() }
-    }
+fun SearchBox(
+    modifier: Modifier = Modifier,
+    userName: String,
+    onTextChanged: (String) -> Unit,
+    onSearch: () -> Unit
+) {
     val keyboardController = LocalSoftwareKeyboardController.current
     Row(modifier = modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
         OutlinedTextField(
             modifier = Modifier
                 .padding(16.dp)
                 .weight(1f),
-            value = text,
-            onValueChange = { text = it },
+            value = userName,
+            onValueChange = onTextChanged,
             label = { Text(text = stringResource(R.string.searchbox_label)) },
             singleLine = true,
             trailingIcon = {
-                if (!isEmpty) {
-                    IconButton(onClick = { text = "" }) {
+                if (userName.isNotEmpty()) {
+                    IconButton(onClick = { onTextChanged("") }) {
                         Icon(
                             Icons.Filled.Cancel,
                             contentDescription = stringResource(R.string.searchbox_clear_button_text)
@@ -130,7 +136,7 @@ fun SearchBox(modifier: Modifier = Modifier, onSearch: (String) -> Unit) {
                 keyboardController?.hide()
             })
         )
-        Button(modifier = Modifier.padding(end = 16.dp), onClick = { onSearch(text) }) {
+        Button(modifier = Modifier.padding(end = 16.dp), onClick = onSearch) {
             Text(text = stringResource(R.string.searchbox_button_text))
         }
     }

--- a/app/src/main/java/com/example/learningandroidapp/viewmodel/UserSearchViewModel.kt
+++ b/app/src/main/java/com/example/learningandroidapp/viewmodel/UserSearchViewModel.kt
@@ -13,6 +13,7 @@ import javax.inject.Inject
 
 
 data class UserSearchUiState(
+    val userName: String = "",
     val userList: List<User> = emptyList(),
     val isLoading: Boolean = false,
     val hasError: Boolean = false,
@@ -25,11 +26,15 @@ class UserSearchViewModel @Inject constructor(
     var uiState by mutableStateOf(UserSearchUiState())
         private set
 
-    fun searchUser(text: String) {
+    fun onUserNameChanged(userName: String) {
+        uiState = uiState.copy(userName = userName)
+    }
+
+    fun searchUser() {
         uiState = uiState.copy(isLoading = true)
         viewModelScope.launch {
             uiState = try {
-                val userList = userRepository.getUserList(text)
+                val userList = userRepository.getUserList(uiState.userName)
                 uiState.copy(isLoading = false, userList = userList)
             } catch (e: Exception) {
                 uiState.copy(isLoading = false, hasError = true, userList = emptyList())

--- a/app/src/test/java/com/example/learningandroidapp/repository/UserRepositoryImplSpec.kt
+++ b/app/src/test/java/com/example/learningandroidapp/repository/UserRepositoryImplSpec.kt
@@ -1,0 +1,71 @@
+package com.example.learningandroidapp.repository
+
+import com.example.learningandroidapp.api.GetUsersResponse
+import com.example.learningandroidapp.api.GitHubApiService
+import com.example.learningandroidapp.api.UserApiModel
+import com.example.learningandroidapp.models.User
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+
+class UserRepositoryImplSpec : DescribeSpec({
+
+    val githubApi = mockk<GitHubApiService>()
+    lateinit var repository: UserRepository
+
+    val getUsersResponse = GetUsersResponse(
+        totalCount = 1,
+        incompleteResults = false,
+        items = listOf(
+            UserApiModel(
+                login = "user",
+                avatarUrl = "https://placehold.jp/240x240.png"
+            )
+        )
+    )
+
+    beforeSpec {
+        repository = UserRepositoryImpl(githubApi)
+    }
+
+    describe("#getUsers") {
+        val query = "user"
+        context("response success") {
+            coEvery {
+                githubApi.getUsers(query)
+            } returns getUsersResponse
+            val response = repository.getUserList(query)
+
+            it("response should be user list") {
+                response shouldBe listOf(
+                    User(
+                        userName = "user",
+                        avatarUrl = "https://placehold.jp/240x240.png"
+                    )
+                )
+            }
+
+            it("verify getUsers") {
+                coVerify(exactly = 1) { githubApi.getUsers(query) }
+            }
+        }
+
+        context("#response fail") {
+            coEvery {
+                githubApi.getUsers(query)
+            } throws Exception()
+
+            it("throw Exception") {
+                shouldThrow<Exception> { repository.getUserList(query) }
+            }
+
+            it("verify getUsers") {
+                coVerify(exactly = 0) { githubApi.getUsers(query) }
+            }
+        }
+    }
+
+})

--- a/app/src/test/java/com/example/learningandroidapp/repository/UserRepositorySpec.kt
+++ b/app/src/test/java/com/example/learningandroidapp/repository/UserRepositorySpec.kt
@@ -11,7 +11,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 
-class UserRepositoryImplSpec : DescribeSpec({
+class UserRepositorySpec : DescribeSpec({
 
     val githubApi = mockk<GitHubApiService>()
     lateinit var repository: UserRepository

--- a/app/src/test/java/com/example/learningandroidapp/util/KotestProjectConfig.kt
+++ b/app/src/test/java/com/example/learningandroidapp/util/KotestProjectConfig.kt
@@ -1,0 +1,9 @@
+package com.example.learningandroidapp.util
+
+import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.spec.IsolationMode
+
+// @see https://kotest.io/docs/framework/integrations/mocking.html#option-3---tweak-the-isolationmode
+class KotestProjectConfig : AbstractProjectConfig() {
+    override val isolationMode = IsolationMode.InstancePerTest
+}

--- a/app/src/test/java/com/example/learningandroidapp/util/MainDispatcherListener.kt
+++ b/app/src/test/java/com/example/learningandroidapp/util/MainDispatcherListener.kt
@@ -1,0 +1,27 @@
+package com.example.learningandroidapp.util
+
+import io.kotest.core.listeners.AfterSpecListener
+import io.kotest.core.listeners.BeforeSpecListener
+import io.kotest.core.spec.Spec
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+
+// @see https://developer.android.com/kotlin/coroutines/test#setting-main-dispatcher
+@ExperimentalCoroutinesApi
+class MainDispatcherListener(
+    private val testDispatcher: TestDispatcher = UnconfinedTestDispatcher()
+) : BeforeSpecListener, AfterSpecListener {
+    override suspend fun beforeSpec(spec: Spec) {
+        super.beforeSpec(spec)
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    override suspend fun afterSpec(spec: Spec) {
+        super.afterSpec(spec)
+        Dispatchers.resetMain()
+    }
+}

--- a/app/src/test/java/com/example/learningandroidapp/viewmodel/UserSearchViewModelSpec.kt
+++ b/app/src/test/java/com/example/learningandroidapp/viewmodel/UserSearchViewModelSpec.kt
@@ -1,0 +1,96 @@
+package com.example.learningandroidapp.viewmodel
+
+import com.example.learningandroidapp.models.User
+import com.example.learningandroidapp.repository.UserRepository
+import com.example.learningandroidapp.util.MainDispatcherListener
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+
+@ExperimentalCoroutinesApi
+class UserSearchViewModelSpec : DescribeSpec({
+
+    extension(MainDispatcherListener())
+
+    val userRepository = mockk<UserRepository>()
+    lateinit var viewModel: UserSearchViewModel
+
+    val userSearchResult = User(
+        userName = "user",
+        avatarUrl = "https://placehold.jp/240x240.png"
+    )
+
+    beforeSpec {
+        viewModel = UserSearchViewModel(userRepository)
+    }
+
+    describe("#onSearchTextChanged") {
+        val inputUserName = "user"
+        context("input user") {
+            viewModel.onUserNameChanged(inputUserName)
+
+            it("searchText should be user") {
+                viewModel.uiState.userName shouldBe inputUserName
+            }
+        }
+    }
+
+    describe("#searchUser") {
+        val inputUserName = "user"
+        context("response success") {
+            coEvery {
+                userRepository.getUserList(inputUserName)
+            } returns listOf(userSearchResult)
+
+            viewModel.onUserNameChanged(inputUserName)
+            viewModel.searchUser()
+
+            it("userList should be collect value") {
+                viewModel.uiState shouldBe UserSearchUiState(
+                    isLoading = false,
+                    userName = inputUserName,
+                    userList = listOf(userSearchResult),
+                    hasError = false
+                )
+            }
+
+            it("verify searchUser") {
+                coVerify(exactly = 1) { userRepository.getUserList(inputUserName) }
+            }
+        }
+
+        context("response fail") {
+            coEvery {
+                userRepository.getUserList(inputUserName)
+            } throws Exception()
+            viewModel.onUserNameChanged(inputUserName)
+            viewModel.searchUser()
+
+            it("event should be FetchError") {
+                viewModel.uiState shouldBe UserSearchUiState(
+                    userName = inputUserName,
+                    hasError = true
+                )
+            }
+
+            it("verify searchUser") {
+                coVerify(exactly = 1) { userRepository.getUserList(inputUserName) }
+            }
+        }
+    }
+
+    describe("#errorMessageShown") {
+        context("consume event") {
+            viewModel.errorMessageShown()
+
+            it("event should be null") {
+                viewModel.uiState.hasError.shouldBeFalse()
+            }
+        }
+    }
+
+})

--- a/app/src/test/java/com/example/learningandroidapp/viewmodel/UserSearchViewModelSpec.kt
+++ b/app/src/test/java/com/example/learningandroidapp/viewmodel/UserSearchViewModelSpec.kt
@@ -19,7 +19,7 @@ class UserSearchViewModelSpec : DescribeSpec({
     val userRepository = mockk<UserRepository>()
     lateinit var viewModel: UserSearchViewModel
 
-    val userSearchResult = User(
+    val user = User(
         userName = "user",
         avatarUrl = "https://placehold.jp/240x240.png"
     )
@@ -28,12 +28,12 @@ class UserSearchViewModelSpec : DescribeSpec({
         viewModel = UserSearchViewModel(userRepository)
     }
 
-    describe("#onSearchTextChanged") {
+    describe("#onUserNameChanged") {
         val inputUserName = "user"
         context("input user") {
             viewModel.onUserNameChanged(inputUserName)
 
-            it("searchText should be user") {
+            it("userName should be user") {
                 viewModel.uiState.userName shouldBe inputUserName
             }
         }
@@ -44,7 +44,7 @@ class UserSearchViewModelSpec : DescribeSpec({
         context("response success") {
             coEvery {
                 userRepository.getUserList(inputUserName)
-            } returns listOf(userSearchResult)
+            } returns listOf(user)
 
             viewModel.onUserNameChanged(inputUserName)
             viewModel.searchUser()
@@ -53,12 +53,12 @@ class UserSearchViewModelSpec : DescribeSpec({
                 viewModel.uiState shouldBe UserSearchUiState(
                     isLoading = false,
                     userName = inputUserName,
-                    userList = listOf(userSearchResult),
+                    userList = listOf(user),
                     hasError = false
                 )
             }
 
-            it("verify searchUser") {
+            it("verify getUserList") {
                 coVerify(exactly = 1) { userRepository.getUserList(inputUserName) }
             }
         }
@@ -77,7 +77,7 @@ class UserSearchViewModelSpec : DescribeSpec({
                 )
             }
 
-            it("verify searchUser") {
+            it("verify getUserList") {
                 coVerify(exactly = 1) { userRepository.getUserList(inputUserName) }
             }
         }


### PR DESCRIPTION
# 背景
- テストコードを追加したい

# やったこと
- ViewModelを唯一の情報源 (Single Source of truth)とするのを原則として、`SearchBox`内でrememberしているTextをViewModelからUiStateとして渡すように修正
  - SearchBoxはStatelessになる
- ViewModelとRepositoryのテストコードをKotestで実装
- 変数名のrename

# テスト結果
CIでテスト通っていることを確認できるのが理想だが、ここではスキップしてlocalで実行したテストケースのスクショを貼る

<img width="652" alt="スクリーンショット 2022-08-09 20 21 41" src="https://user-images.githubusercontent.com/19250035/183635879-a83fb920-1d1d-4bb8-98a6-aec833165c46.png">
<img width="643" alt="スクリーンショット 2022-08-09 20 23 56" src="https://user-images.githubusercontent.com/19250035/183635882-00f39f6a-231d-4975-a619-9a1782183e99.png">

# 確認方法
Android Studio > Preferences > Plugin からkotestをインストールしておきましょう

Specのclassの横にあるRunアイコンをクリックするか、下記のgradleコマンドでテストを実行できます。
describe以下を個別実行するとmockkでエラーが起きるので利用できないみたいです

```
./gradlew app:testDebugUnitTest --tests com.example.learningandroidapp.repository.UserRepositorySpec
```

# レビューポイント
- Searchboxの変更良いか
- テストコードわからないことないか

# 参考資料
- https://kotest.io/docs/5.3/quickstart
- https://mockk.io/