### PR TITLE
ユーザ詳細画面のViewModelの実装

### DIFF
--- a/app/src/main/java/com/example/learningandroidapp/UserDetailActivity.kt
+++ b/app/src/main/java/com/example/learningandroidapp/UserDetailActivity.kt
@@ -3,8 +3,10 @@ package com.example.learningandroidapp
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.viewModels
 import com.example.learningandroidapp.ui.UserDetailScreen
 import com.example.learningandroidapp.ui.theme.LearningAndroidAppTheme
+import com.example.learningandroidapp.viewmodel.UserDetailViewModel
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -12,9 +14,11 @@ class UserDetailActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val userName = intent?.extras?.getString("userName") ?: throw NullPointerException()
+        val viewModel by viewModels<UserDetailViewModel>()
+        viewModel.loadUserDetail(userName)
         setContent {
             LearningAndroidAppTheme {
-                UserDetailScreen(userName)
+                UserDetailScreen(viewModel = viewModel)
             }
         }
     }

--- a/app/src/main/java/com/example/learningandroidapp/UserDetailActivity.kt
+++ b/app/src/main/java/com/example/learningandroidapp/UserDetailActivity.kt
@@ -5,7 +5,9 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import com.example.learningandroidapp.ui.UserDetailScreen
 import com.example.learningandroidapp.ui.theme.LearningAndroidAppTheme
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class UserDetailActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/example/learningandroidapp/models/UserDetail.kt
+++ b/app/src/main/java/com/example/learningandroidapp/models/UserDetail.kt
@@ -5,6 +5,5 @@ data class UserDetail(
     val screenName: String,
     val avatarUrl: String,
     val followers: Int,
-    val following: Int,
-    val repos: List<UserRepo>
+    val following: Int
 )

--- a/app/src/main/java/com/example/learningandroidapp/ui/UserDetail.kt
+++ b/app/src/main/java/com/example/learningandroidapp/ui/UserDetail.kt
@@ -27,36 +27,38 @@ import com.example.learningandroidapp.R
 import com.example.learningandroidapp.models.UserDetail
 import com.example.learningandroidapp.models.UserRepo
 import com.example.learningandroidapp.ui.theme.LearningAndroidAppTheme
+import com.example.learningandroidapp.viewmodel.UserDetailUiState
+import com.example.learningandroidapp.viewmodel.UserDetailViewModel
 
 @Composable
-fun UserDetailScreen(userName: String) {
+fun UserDetailScreen(viewModel: UserDetailViewModel = androidx.lifecycle.viewmodel.compose.viewModel()) {
     val activity = (LocalContext.current as Activity)
-    UserDetailContent(userName = userName, onClickNavigationIcon = { activity.finish() })
+    UserDetailContent(viewModel.uiState, onClickNavigationIcon = { activity.finish() })
 }
 
 @Preview
 @Composable
 private fun UserDetailContentPreview() {
+    val uiState = UserDetailUiState(
+        userRepos = emptyList(),
+        userDetail = UserDetail(
+            userName = "ユーザー名",
+            screenName = "スクリーンネーム",
+            avatarUrl = "",
+            following = 0,
+            followers = 0
+        )
+    )
     LearningAndroidAppTheme {
-        UserDetailContent("ユーザー名") {}
+        UserDetailContent(uiState = uiState, onClickNavigationIcon = {})
     }
 }
 
 @Composable
-private fun UserDetailContent(userName: String, onClickNavigationIcon: () -> Unit) {
-    val repos = listOf(
-        UserRepo(name = "リポジトリ1", description = "description1", language = "Kotlin", star = 1),
-        UserRepo(name = "リポジトリ2", description = "description2", language = "Java", star = 11),
-        UserRepo(name = "リポジトリ3", description = "description3", language = "Scala", star = 111)
-    )
-    val userDetail = UserDetail(
-        userName = userName,
-        screenName = "スクリーンネーム",
-        avatarUrl = "",
-        followers = 0,
-        following = 0,
-        repos = repos
-    )
+private fun UserDetailContent(
+    uiState: UserDetailUiState,
+    onClickNavigationIcon: () -> Unit
+) {
     Scaffold(
         topBar = {
             TopAppBar(
@@ -70,9 +72,17 @@ private fun UserDetailContent(userName: String, onClickNavigationIcon: () -> Uni
                 }
             )
         }) {
-        Column {
-            UserInfo(userDetail)
-            UserRepositoryCardList(repos = userDetail.repos)
+        if (uiState.isLoading) {
+            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator()
+            }
+        } else {
+            val repos = uiState.userRepos
+            val userDetail = uiState.userDetail ?: throw NullPointerException()
+            Column {
+                UserInfo(userDetail)
+                UserRepositoryCardList(repos = repos)
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/learningandroidapp/ui/UserDetail.kt
+++ b/app/src/main/java/com/example/learningandroidapp/ui/UserDetail.kt
@@ -85,8 +85,7 @@ private fun UserInfoPreview() {
         screenName = "スクリーンネーム",
         avatarUrl = "",
         followers = 0,
-        following = 0,
-        repos = emptyList()
+        following = 0
     )
     LearningAndroidAppTheme {
         UserInfo(userDetail)

--- a/app/src/main/java/com/example/learningandroidapp/ui/UserDetail.kt
+++ b/app/src/main/java/com/example/learningandroidapp/ui/UserDetail.kt
@@ -9,6 +9,7 @@ import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -31,9 +32,26 @@ import com.example.learningandroidapp.viewmodel.UserDetailUiState
 import com.example.learningandroidapp.viewmodel.UserDetailViewModel
 
 @Composable
-fun UserDetailScreen(viewModel: UserDetailViewModel = androidx.lifecycle.viewmodel.compose.viewModel()) {
+fun UserDetailScreen(
+    viewModel: UserDetailViewModel = androidx.lifecycle.viewmodel.compose.viewModel(),
+    scaffoldState: ScaffoldState = rememberScaffoldState()
+) {
     val activity = (LocalContext.current as Activity)
-    UserDetailContent(viewModel.uiState, onClickNavigationIcon = { activity.finish() })
+    val hasError = @Composable {
+        val context = LocalContext.current
+        LaunchedEffect(scaffoldState.snackbarHostState) {
+            scaffoldState.snackbarHostState.showSnackbar(
+                message = context.getString(R.string.network_error_message)
+            )
+            viewModel.errorMessageShown()
+        }
+    }
+    UserDetailContent(
+        viewModel.uiState,
+        scaffoldState,
+        onClickNavigationIcon = { activity.finish() },
+        hasError = hasError
+    )
 }
 
 @Preview
@@ -50,16 +68,27 @@ private fun UserDetailContentPreview() {
         )
     )
     LearningAndroidAppTheme {
-        UserDetailContent(uiState = uiState, onClickNavigationIcon = {})
+        UserDetailContent(
+            uiState = uiState,
+            onClickNavigationIcon = {},
+            hasError = {},
+            scaffoldState = rememberScaffoldState()
+        )
     }
 }
 
 @Composable
 private fun UserDetailContent(
     uiState: UserDetailUiState,
-    onClickNavigationIcon: () -> Unit
+    scaffoldState: ScaffoldState,
+    onClickNavigationIcon: () -> Unit,
+    hasError: @Composable () -> Unit
 ) {
+    if (uiState.hasError) {
+        hasError()
+    }
     Scaffold(
+        scaffoldState = scaffoldState,
         topBar = {
             TopAppBar(
                 title = {

--- a/app/src/main/java/com/example/learningandroidapp/viewmodel/UserDetailViewModel.kt
+++ b/app/src/main/java/com/example/learningandroidapp/viewmodel/UserDetailViewModel.kt
@@ -1,0 +1,39 @@
+package com.example.learningandroidapp.viewmodel
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import com.example.learningandroidapp.models.UserDetail
+import com.example.learningandroidapp.models.UserRepo
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+data class UserDetailUiState(
+    val userDetail: UserDetail? = null,
+    val userRepos: List<UserRepo> = emptyList(),
+    val isLoading: Boolean = false,
+    val hasError: Boolean = false,
+)
+
+@HiltViewModel
+class UserDetailViewModel @Inject constructor() : ViewModel() {
+    var uiState by mutableStateOf(UserDetailUiState())
+        private set
+
+    fun loadUserDetail(userName: String) {
+        val userDetail = UserDetail(
+            userName = userName,
+            screenName = userName.uppercase(),
+            avatarUrl = "",
+            followers = 0,
+            following = 0
+        )
+
+        val repos = listOf(
+            UserRepo(userName, "description", "Kotlin", 12)
+        )
+
+        uiState = uiState.copy(userRepos = repos, userDetail = userDetail)
+    }
+}

--- a/app/src/main/java/com/example/learningandroidapp/viewmodel/UserDetailViewModel.kt
+++ b/app/src/main/java/com/example/learningandroidapp/viewmodel/UserDetailViewModel.kt
@@ -4,9 +4,11 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.example.learningandroidapp.models.UserDetail
 import com.example.learningandroidapp.models.UserRepo
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 data class UserDetailUiState(
@@ -22,18 +24,34 @@ class UserDetailViewModel @Inject constructor() : ViewModel() {
         private set
 
     fun loadUserDetail(userName: String) {
-        val userDetail = UserDetail(
-            userName = userName,
-            screenName = userName.uppercase(),
-            avatarUrl = "",
-            followers = 0,
-            following = 0
-        )
+        uiState = uiState.copy(isLoading = true)
+        viewModelScope.launch {
+            try {
+                val userDetail = UserDetail(
+                    userName = userName,
+                    screenName = userName.uppercase(),
+                    avatarUrl = "",
+                    followers = 0,
+                    following = 0
+                )
 
-        val repos = listOf(
-            UserRepo(userName, "description", "Kotlin", 12)
-        )
+                val repos = listOf(
+                    UserRepo(userName, "description", "Kotlin", 12)
+                )
 
-        uiState = uiState.copy(userRepos = repos, userDetail = userDetail)
+                uiState =
+                    uiState.copy(
+                        isLoading = false,
+                        userRepos = repos,
+                        userDetail = userDetail
+                    )
+            } catch (e: Exception) {
+                uiState = uiState.copy(isLoading = false, hasError = true)
+            }
+        }
+    }
+
+    fun errorMessageShown() {
+        uiState = uiState.copy(hasError = false)
     }
 }


### PR DESCRIPTION
### 概要
- 検索結果から遷移するユーザ詳細画面の実装
  - ViewModelの実装

### 変更点
- models/UserDetailの中にUserRepoを持たないように変更
- uiでViewModelを使用するように変更
- uiにエラーメッセージを表示するスナックバーの処理を追加