### PR TITLE
ユーザー詳細画面のAPI実装

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -80,6 +80,7 @@ dependencies {
     androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"
     debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
     debugImplementation "androidx.compose.ui:ui-test-manifest:$compose_version"
+    implementation "androidx.browser:browser:1.3.0"
 
     // Kotest
     testImplementation 'io.kotest:kotest-runner-junit5:5.3.2'

--- a/app/src/main/java/com/example/learningandroidapp/UserDetailActivity.kt
+++ b/app/src/main/java/com/example/learningandroidapp/UserDetailActivity.kt
@@ -1,9 +1,11 @@
 package com.example.learningandroidapp
 
+import android.net.Uri
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
+import androidx.browser.customtabs.CustomTabsIntent
 import com.example.learningandroidapp.ui.UserDetailScreen
 import com.example.learningandroidapp.ui.theme.LearningAndroidAppTheme
 import com.example.learningandroidapp.viewmodel.UserDetailViewModel
@@ -16,9 +18,13 @@ class UserDetailActivity : ComponentActivity() {
         val userName = intent?.extras?.getString("userName") ?: throw NullPointerException()
         val viewModel by viewModels<UserDetailViewModel>()
         viewModel.loadUserDetail(userName)
+        val onNavigate = { url: String ->
+            val customTabsIntent = CustomTabsIntent.Builder().build()
+            customTabsIntent.launchUrl(this, Uri.parse(url))
+        }
         setContent {
             LearningAndroidAppTheme {
-                UserDetailScreen(viewModel = viewModel)
+                UserDetailScreen(viewModel = viewModel, onNavigate = onNavigate)
             }
         }
     }

--- a/app/src/main/java/com/example/learningandroidapp/api/GitHubApiService.kt
+++ b/app/src/main/java/com/example/learningandroidapp/api/GitHubApiService.kt
@@ -19,7 +19,12 @@ interface GitHubApiService {
         "Accept: application/vnd.github+json"
     )
     @GET("users/{username}/repos")
-    suspend fun getUserRepos(@Path("username") userName: String): List<UserRepoApiModel>
+    suspend fun getUserRepos(
+        @Path("username") userName: String,
+        @Query("sort") sort: String = "pushed",
+        @Query("per_page") perPage: Int = 100,
+        @Query("page") page: Int = 1,
+    ): List<UserRepoApiModel>
 
     @Headers(
         "Authorization: token ${BuildConfig.GITHUB_TOKEN}",

--- a/app/src/main/java/com/example/learningandroidapp/api/GitHubApiService.kt
+++ b/app/src/main/java/com/example/learningandroidapp/api/GitHubApiService.kt
@@ -3,6 +3,7 @@ package com.example.learningandroidapp.api
 import com.example.learningandroidapp.BuildConfig
 import retrofit2.http.GET
 import retrofit2.http.Headers
+import retrofit2.http.Path
 import retrofit2.http.Query
 
 interface GitHubApiService {
@@ -13,4 +14,17 @@ interface GitHubApiService {
     @GET("search/users")
     suspend fun getUsers(@Query("q") query: String): GetUsersResponse
 
+    @Headers(
+        "Authorization: token ${BuildConfig.GITHUB_TOKEN}",
+        "Accept: application/vnd.github+json"
+    )
+    @GET("users/{username}/repos")
+    suspend fun getUserRepos(@Path("username") userName: String): List<UserRepoApiModel>
+
+    @Headers(
+        "Authorization: token ${BuildConfig.GITHUB_TOKEN}",
+        "Accept: application/vnd.github+json"
+    )
+    @GET("users/{username}")
+    suspend fun getUserDetail(@Path("username") userName: String): UserDetailApiModel
 }

--- a/app/src/main/java/com/example/learningandroidapp/api/GitHubApiService.kt
+++ b/app/src/main/java/com/example/learningandroidapp/api/GitHubApiService.kt
@@ -22,7 +22,7 @@ interface GitHubApiService {
     suspend fun getUserRepos(
         @Path("username") userName: String,
         @Query("sort") sort: String = "pushed",
-        @Query("per_page") perPage: Int = 100,
+        @Query("per_page") perPage: Int = 50,
         @Query("page") page: Int = 1,
     ): List<UserRepoApiModel>
 

--- a/app/src/main/java/com/example/learningandroidapp/api/UserDetailApiModel.kt
+++ b/app/src/main/java/com/example/learningandroidapp/api/UserDetailApiModel.kt
@@ -1,0 +1,9 @@
+package com.example.learningandroidapp.api
+
+data class UserDetailApiModel(
+    val login: String,
+    val name: String,
+    val avatarUrl: String,
+    val followers: Int,
+    val following: Int
+)

--- a/app/src/main/java/com/example/learningandroidapp/api/UserRepoApiModel.kt
+++ b/app/src/main/java/com/example/learningandroidapp/api/UserRepoApiModel.kt
@@ -3,7 +3,7 @@ package com.example.learningandroidapp.api
 data class UserRepoApiModel(
     val name: String,
     val description: String?,
-    val forked: Boolean,
+    val fork: Boolean,
     val language: String?,
     val stargazersCount: Int,
 )

--- a/app/src/main/java/com/example/learningandroidapp/api/UserRepoApiModel.kt
+++ b/app/src/main/java/com/example/learningandroidapp/api/UserRepoApiModel.kt
@@ -6,4 +6,5 @@ data class UserRepoApiModel(
     val fork: Boolean,
     val language: String?,
     val stargazersCount: Int,
+    val htmlUrl: String,
 )

--- a/app/src/main/java/com/example/learningandroidapp/api/UserRepoApiModel.kt
+++ b/app/src/main/java/com/example/learningandroidapp/api/UserRepoApiModel.kt
@@ -5,5 +5,5 @@ data class UserRepoApiModel(
     val description: String?,
     val forked: Boolean,
     val language: String?,
-    val stargazers_count: Int,
+    val stargazersCount: Int,
 )

--- a/app/src/main/java/com/example/learningandroidapp/api/UserRepoApiModel.kt
+++ b/app/src/main/java/com/example/learningandroidapp/api/UserRepoApiModel.kt
@@ -1,0 +1,9 @@
+package com.example.learningandroidapp.api
+
+data class UserRepoApiModel(
+    val name: String,
+    val description: String?,
+    val forked: Boolean,
+    val language: String?,
+    val stargazers_count: Int,
+)

--- a/app/src/main/java/com/example/learningandroidapp/models/UserRepo.kt
+++ b/app/src/main/java/com/example/learningandroidapp/models/UserRepo.kt
@@ -5,5 +5,6 @@ data class UserRepo(
     val description: String,
     val language: String,
     val star: Int,
-    val url: String
+    val url: String,
+    val isForked: Boolean,
 )

--- a/app/src/main/java/com/example/learningandroidapp/models/UserRepo.kt
+++ b/app/src/main/java/com/example/learningandroidapp/models/UserRepo.kt
@@ -5,4 +5,5 @@ data class UserRepo(
     val description: String,
     val language: String,
     val star: Int,
+    val url: String
 )

--- a/app/src/main/java/com/example/learningandroidapp/repository/UserDetailRepositoryImpl.kt
+++ b/app/src/main/java/com/example/learningandroidapp/repository/UserDetailRepositoryImpl.kt
@@ -17,7 +17,7 @@ class UserDetailRepositoryImpl @Inject constructor(
     override suspend fun getUserDetail(userName: String): UserDetail {
         return coroutineScope {
             val userDetail = async { gitHubApi.getUserDetail(userName) }
-            val userRepos = async { gitHubApi.getUserRepos(userName, perPage = 50) }
+            val userRepos = async { gitHubApi.getUserRepos(userName) }
 
             convertToUserDetail(userDetail.await(), userRepos.await())
         }

--- a/app/src/main/java/com/example/learningandroidapp/repository/UserDetailRepositoryImpl.kt
+++ b/app/src/main/java/com/example/learningandroidapp/repository/UserDetailRepositoryImpl.kt
@@ -51,6 +51,7 @@ class UserDetailRepositoryImpl @Inject constructor(
                     description = it.description ?: "",
                     language = it.language ?: "",
                     star = it.stargazersCount,
+                    url = it.htmlUrl
                 )
             }
         return UserDetail(

--- a/app/src/main/java/com/example/learningandroidapp/repository/UserDetailRepositoryImpl.kt
+++ b/app/src/main/java/com/example/learningandroidapp/repository/UserDetailRepositoryImpl.kt
@@ -33,7 +33,7 @@ class UserDetailRepositoryImpl @Inject constructor(
                 name = it.name,
                 description = it.description ?: "",
                 language = it.language ?: "",
-                star = it.stargazers_count,
+                star = it.stargazersCount,
             )
         }
         return UserDetail(

--- a/app/src/main/java/com/example/learningandroidapp/repository/UserDetailRepositoryImpl.kt
+++ b/app/src/main/java/com/example/learningandroidapp/repository/UserDetailRepositoryImpl.kt
@@ -17,24 +17,10 @@ class UserDetailRepositoryImpl @Inject constructor(
     override suspend fun getUserDetail(userName: String): UserDetail {
         return coroutineScope {
             val userDetail = async { gitHubApi.getUserDetail(userName) }
-            val userRepos = async { getUserRepos(userName) }
+            val userRepos = async { gitHubApi.getUserRepos(userName, perPage = 50) }
 
             convertToUserDetail(userDetail.await(), userRepos.await())
         }
-    }
-
-    private suspend fun getUserRepos(userName: String): List<UserRepoApiModel> {
-        val userRepos = mutableListOf<UserRepoApiModel>()
-        var requestPageIndex = 1
-        while (true) {
-            val repos = gitHubApi.getUserRepos(userName, page = requestPageIndex)
-            requestPageIndex++
-            if (repos.isEmpty()) {
-                break
-            }
-            userRepos.addAll(repos)
-        }
-        return userRepos
     }
 
     private fun convertToUserDetail(

--- a/app/src/main/java/com/example/learningandroidapp/repository/UserDetailRepositoryImpl.kt
+++ b/app/src/main/java/com/example/learningandroidapp/repository/UserDetailRepositoryImpl.kt
@@ -1,8 +1,12 @@
 package com.example.learningandroidapp.repository
 
 import com.example.learningandroidapp.api.GitHubApiService
+import com.example.learningandroidapp.api.UserDetailApiModel
+import com.example.learningandroidapp.api.UserRepoApiModel
 import com.example.learningandroidapp.models.UserDetail
 import com.example.learningandroidapp.models.UserRepo
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -11,16 +15,34 @@ class UserDetailRepositoryImpl @Inject constructor(
     private val gitHubApi: GitHubApiService
 ) : UserDetailRepository {
     override suspend fun getUserDetail(userName: String): UserDetail {
-        // TODO APIを並列で呼ぶ
-        return UserDetail(
-            userName = userName,
-            screenName = userName.uppercase(),
-            avatarUrl = "",
-            followers = 2,
-            following = 2,
-            repos = listOf(
-                UserRepo(userName, "description", "Kotlin", 24)
+        return coroutineScope {
+            val userDetail = async { gitHubApi.getUserDetail(userName) }
+            val userRepos = async { gitHubApi.getUserRepos(userName) }
+
+            convertUserDetail(userDetail.await(), userRepos.await())
+        }
+    }
+
+    private fun convertUserDetail(
+        userDetailApiModel: UserDetailApiModel,
+        userRepoApiModels: List<UserRepoApiModel>
+    ): UserDetail {
+        // TODO owner, forkのチェック
+        val repos = userRepoApiModels.map {
+            UserRepo(
+                name = it.name,
+                description = it.description ?: "",
+                language = it.language ?: "",
+                star = it.stargazers_count,
             )
+        }
+        return UserDetail(
+            userName = userDetailApiModel.login,
+            avatarUrl = userDetailApiModel.avatarUrl,
+            screenName = userDetailApiModel.name,
+            followers = userDetailApiModel.followers,
+            following = userDetailApiModel.following,
+            repos = repos
         )
     }
 }

--- a/app/src/main/java/com/example/learningandroidapp/repository/UserDetailRepositoryImpl.kt
+++ b/app/src/main/java/com/example/learningandroidapp/repository/UserDetailRepositoryImpl.kt
@@ -20,7 +20,7 @@ class UserDetailRepositoryImpl @Inject constructor(
             val userDetail = async { gitHubApi.getUserDetail(userName) }
             val userRepos = async { getUserRepos(userName) }
 
-            convertUserDetail(userDetail.await(), userRepos.await())
+            convertToUserDetail(userDetail.await(), userRepos.await())
         }
     }
 
@@ -39,7 +39,7 @@ class UserDetailRepositoryImpl @Inject constructor(
         return userRepos.slice(0 until min(50, userRepos.size))
     }
 
-    private fun convertUserDetail(
+    private fun convertToUserDetail(
         userDetailApiModel: UserDetailApiModel,
         userRepoApiModels: List<UserRepoApiModel>
     ): UserDetail {

--- a/app/src/main/java/com/example/learningandroidapp/ui/UserDetail.kt
+++ b/app/src/main/java/com/example/learningandroidapp/ui/UserDetail.kt
@@ -101,16 +101,18 @@ private fun UserDetailContent(
                 }
             )
         }) {
-        if (uiState.isLoading || uiState.hasError) {
+        if (uiState.isLoading) {
             Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                 CircularProgressIndicator()
             }
         } else {
             val repos = uiState.userRepos
-            val userDetail = uiState.userDetail ?: throw NullPointerException()
-            Column {
-                UserInfo(userDetail)
-                UserRepositoryCardList(repos = repos)
+            val userDetail = uiState.userDetail
+            if (userDetail != null) {
+                Column {
+                    UserInfo(userDetail)
+                    UserRepositoryCardList(repos = repos)
+                }
             }
         }
     }

--- a/app/src/main/java/com/example/learningandroidapp/ui/UserDetail.kt
+++ b/app/src/main/java/com/example/learningandroidapp/ui/UserDetail.kt
@@ -101,7 +101,7 @@ private fun UserDetailContent(
                 }
             )
         }) {
-        if (uiState.isLoading) {
+        if (uiState.isLoading || uiState.hasError) {
             Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                 CircularProgressIndicator()
             }

--- a/app/src/main/java/com/example/learningandroidapp/ui/UserDetail.kt
+++ b/app/src/main/java/com/example/learningandroidapp/ui/UserDetail.kt
@@ -229,7 +229,8 @@ private fun UserRepositoryCardPreview() {
         description = "description",
         language = "Kotlin",
         star = 0,
-        url = ""
+        url = "",
+        isForked = false
     )
     LearningAndroidAppTheme {
         UserRepositoryCard(repo, onClick = {})

--- a/app/src/main/java/com/example/learningandroidapp/ui/UserDetail.kt
+++ b/app/src/main/java/com/example/learningandroidapp/ui/UserDetail.kt
@@ -1,6 +1,7 @@
 package com.example.learningandroidapp.ui
 
 import android.app.Activity
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -34,7 +35,8 @@ import com.example.learningandroidapp.viewmodel.UserDetailViewModel
 @Composable
 fun UserDetailScreen(
     viewModel: UserDetailViewModel = androidx.lifecycle.viewmodel.compose.viewModel(),
-    scaffoldState: ScaffoldState = rememberScaffoldState()
+    scaffoldState: ScaffoldState = rememberScaffoldState(),
+    onNavigate: (String) -> Unit
 ) {
     val activity = (LocalContext.current as Activity)
     val hasError = @Composable {
@@ -50,7 +52,8 @@ fun UserDetailScreen(
         viewModel.uiState,
         scaffoldState,
         onClickNavigationIcon = { activity.finish() },
-        hasError = hasError
+        hasError = hasError,
+        onNavigate = onNavigate
     )
 }
 
@@ -72,7 +75,8 @@ private fun UserDetailContentPreview() {
             uiState = uiState,
             onClickNavigationIcon = {},
             hasError = {},
-            scaffoldState = rememberScaffoldState()
+            scaffoldState = rememberScaffoldState(),
+            onNavigate = {}
         )
     }
 }
@@ -82,7 +86,8 @@ private fun UserDetailContent(
     uiState: UserDetailUiState,
     scaffoldState: ScaffoldState,
     onClickNavigationIcon: () -> Unit,
-    hasError: @Composable () -> Unit
+    hasError: @Composable () -> Unit,
+    onNavigate: (String) -> Unit
 ) {
     if (uiState.hasError) {
         hasError()
@@ -111,7 +116,7 @@ private fun UserDetailContent(
             if (userDetail != null) {
                 Column {
                     UserInfo(userDetail)
-                    UserRepositoryCardList(repos = repos)
+                    UserRepositoryCardList(repos = repos, onNavigate = onNavigate)
                 }
             }
         }
@@ -191,12 +196,12 @@ private fun UserInfo(userDetail: UserDetail) {
 @Composable
 private fun UserRepositoryCardListEmptyPreview() {
     LearningAndroidAppTheme {
-        UserRepositoryCardList(repos = emptyList())
+        UserRepositoryCardList(repos = emptyList(), onNavigate = {})
     }
 }
 
 @Composable
-private fun UserRepositoryCardList(repos: List<UserRepo>) {
+private fun UserRepositoryCardList(repos: List<UserRepo>, onNavigate: (String) -> Unit) {
     if (repos.isEmpty()) {
         Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
             Text(text = stringResource(R.string.empty_repository_message))
@@ -210,7 +215,7 @@ private fun UserRepositoryCardList(repos: List<UserRepo>) {
             contentPadding = PaddingValues(vertical = 8.dp)
         ) {
             items(items = repos) { repo ->
-                UserRepositoryCard(repo = repo)
+                UserRepositoryCard(repo = repo, onClick = { onNavigate(repo.url) })
             }
         }
     }
@@ -219,17 +224,24 @@ private fun UserRepositoryCardList(repos: List<UserRepo>) {
 @Preview(showBackground = true)
 @Composable
 private fun UserRepositoryCardPreview() {
-    val repo = UserRepo(name = "リポジトリ名", description = "description", language = "Kotlin", star = 0)
+    val repo = UserRepo(
+        name = "リポジトリ名",
+        description = "description",
+        language = "Kotlin",
+        star = 0,
+        url = ""
+    )
     LearningAndroidAppTheme {
-        UserRepositoryCard(repo)
+        UserRepositoryCard(repo, onClick = {})
     }
 }
 
 @Composable
-private fun UserRepositoryCard(repo: UserRepo) {
+private fun UserRepositoryCard(repo: UserRepo, onClick: () -> Unit) {
     Card(
         modifier = Modifier
-            .fillMaxWidth(),
+            .fillMaxWidth()
+            .clickable { onClick() },
         elevation = 3.dp
     ) {
         Column(modifier = Modifier.padding(16.dp)) {

--- a/app/src/main/java/com/example/learningandroidapp/ui/UserDetail.kt
+++ b/app/src/main/java/com/example/learningandroidapp/ui/UserDetail.kt
@@ -61,13 +61,13 @@ fun UserDetailScreen(
 @Composable
 private fun UserDetailContentPreview() {
     val uiState = UserDetailUiState(
-        userRepos = emptyList(),
         userDetail = UserDetail(
             userName = "ユーザー名",
             screenName = "スクリーンネーム",
             avatarUrl = "",
             following = 0,
-            followers = 0
+            followers = 0,
+            repos = emptyList()
         )
     )
     LearningAndroidAppTheme {
@@ -111,9 +111,9 @@ private fun UserDetailContent(
                 CircularProgressIndicator()
             }
         } else {
-            val repos = uiState.userRepos
             val userDetail = uiState.userDetail
             if (userDetail != null) {
+                val repos = userDetail.repos
                 Column {
                     UserInfo(userDetail)
                     UserRepositoryCardList(repos = repos, onNavigate = onNavigate)

--- a/app/src/main/java/com/example/learningandroidapp/viewmodel/UserDetailViewModel.kt
+++ b/app/src/main/java/com/example/learningandroidapp/viewmodel/UserDetailViewModel.kt
@@ -6,7 +6,6 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.learningandroidapp.models.UserDetail
-import com.example.learningandroidapp.models.UserRepo
 import com.example.learningandroidapp.repository.UserDetailRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
@@ -14,7 +13,6 @@ import javax.inject.Inject
 
 data class UserDetailUiState(
     val userDetail: UserDetail? = null,
-    val userRepos: List<UserRepo> = emptyList(),
     val isLoading: Boolean = false,
     val hasError: Boolean = false,
 )
@@ -35,8 +33,7 @@ class UserDetailViewModel @Inject constructor(
 
                 uiState.copy(
                     isLoading = false,
-                    userRepos = repos,
-                    userDetail = userDetail
+                    userDetail = userDetail.copy(repos = repos)
                 )
             } catch (e: Exception) {
                 uiState.copy(isLoading = false, hasError = true)

--- a/app/src/main/java/com/example/learningandroidapp/viewmodel/UserDetailViewModel.kt
+++ b/app/src/main/java/com/example/learningandroidapp/viewmodel/UserDetailViewModel.kt
@@ -31,7 +31,7 @@ class UserDetailViewModel @Inject constructor(
         viewModelScope.launch {
             uiState = try {
                 val userDetail = userDetailRepository.getUserDetail(userName)
-                val repos = userDetail.repos.filter { !it.isForked }.take(50)
+                val repos = userDetail.repos.filter { !it.isForked }
 
                 uiState.copy(
                     isLoading = false,

--- a/app/src/main/java/com/example/learningandroidapp/viewmodel/UserDetailViewModel.kt
+++ b/app/src/main/java/com/example/learningandroidapp/viewmodel/UserDetailViewModel.kt
@@ -31,7 +31,7 @@ class UserDetailViewModel @Inject constructor(
         viewModelScope.launch {
             uiState = try {
                 val userDetail = userDetailRepository.getUserDetail(userName)
-                val repos = userDetail.repos
+                val repos = userDetail.repos.filter { !it.isForked }.take(50)
 
                 uiState.copy(
                     isLoading = false,


### PR DESCRIPTION
### 概要
- 検索結果から遷移するユーザ詳細画面の実装
  -  APIの実装

### 変更点
- GitHubApiServiceにユーザの詳細取得とユーザのリポジトリ取得を追加
  - api/にそれぞれの取得データのモデルを追加 
- UserDetailRepositoryでAPIから値を取得するように変更
- リポジトリのカードをクリックした時に詳細を表示するように変更

### テスト結果