### PR TITLE
ユーザー詳細画面のユニットテストの実装

### DIFF
--- a/app/src/test/java/com/example/learningandroidapp/repository/UserDetailRepositorySpec.kt
+++ b/app/src/test/java/com/example/learningandroidapp/repository/UserDetailRepositorySpec.kt
@@ -1,0 +1,122 @@
+package com.example.learningandroidapp.repository
+
+import com.example.learningandroidapp.api.GitHubApiService
+import com.example.learningandroidapp.api.UserDetailApiModel
+import com.example.learningandroidapp.api.UserRepoApiModel
+import com.example.learningandroidapp.models.UserDetail
+import com.example.learningandroidapp.models.UserRepo
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+
+class UserDetailRepositorySpec : DescribeSpec({
+    val githubApi = mockk<GitHubApiService>()
+    lateinit var repository: UserDetailRepository
+
+    val userDetailApiModel = UserDetailApiModel(
+        name = "User",
+        login = "user",
+        following = 8,
+        followers = 16,
+        avatarUrl = "https://placehold.jp/240x240.png"
+    )
+    val userRepos = listOf(
+        UserRepoApiModel(
+            name = "Repository1",
+            description = "Description1",
+            language = "Kotlin",
+            fork = false,
+            htmlUrl = "https://example.com/1",
+            stargazersCount = 1
+        ),
+    )
+
+    beforeSpec {
+        repository = UserDetailRepositoryImpl(githubApi)
+    }
+
+    describe("#getUserDetail") {
+        val query = "user"
+        context("response success") {
+            coEvery {
+                githubApi.getUserDetail(query)
+            } returns userDetailApiModel
+            coEvery {
+                githubApi.getUserRepos(query)
+            } returns userRepos
+
+            val response = repository.getUserDetail(query)
+
+            it("response should be user detail") {
+                response shouldBe UserDetail(
+                    userName = "user",
+                    screenName = "User",
+                    avatarUrl = "https://placehold.jp/240x240.png",
+                    following = 8,
+                    followers = 16,
+                    repos = listOf(
+                        UserRepo(
+                            name = "Repository1",
+                            description = "Description1",
+                            language = "Kotlin",
+                            isForked = false,
+                            url = "https://example.com/1",
+                            star = 1,
+                        )
+                    )
+                )
+            }
+
+            it("verify getUserDetail") {
+                coVerify(exactly = 1) { githubApi.getUserDetail(query) }
+            }
+            it("verify getUserRepos") {
+                coVerify(exactly = 1) { githubApi.getUserRepos(query) }
+            }
+        }
+
+        context("response fail") {
+            context("fail getUserDetail") {
+                coEvery {
+                    githubApi.getUserDetail(query)
+                } throws Exception()
+                coEvery {
+                    githubApi.getUserRepos(query)
+                } returns userRepos
+
+                it("throw Exception") {
+                    shouldThrow<Exception> { repository.getUserDetail(query) }
+                }
+
+                it("verify getUserDetail") {
+                    coVerify(exactly = 0) { githubApi.getUserDetail(query) }
+                }
+                it("verify getUserRepos") {
+                    coVerify(exactly = 0) { githubApi.getUserRepos(query) }
+                }
+            }
+            context("fail getUserRepos") {
+                coEvery {
+                    githubApi.getUserDetail(query)
+                } returns userDetailApiModel
+                coEvery {
+                    githubApi.getUserRepos(query)
+                } throws Exception()
+
+                it("throw Exception") {
+                    shouldThrow<Exception> { repository.getUserDetail(query) }
+                }
+
+                it("verify getUserDetail") {
+                    coVerify(exactly = 0) { githubApi.getUserDetail(query) }
+                }
+                it("verify getUserRepos") {
+                    coVerify(exactly = 0) { githubApi.getUserRepos(query) }
+                }
+            }
+        }
+    }
+})

--- a/app/src/test/java/com/example/learningandroidapp/viewmodel/UserDetailViewModelSpec.kt
+++ b/app/src/test/java/com/example/learningandroidapp/viewmodel/UserDetailViewModelSpec.kt
@@ -1,0 +1,116 @@
+package com.example.learningandroidapp.viewmodel
+
+import com.example.learningandroidapp.models.UserDetail
+import com.example.learningandroidapp.models.UserRepo
+import com.example.learningandroidapp.repository.UserDetailRepository
+import com.example.learningandroidapp.util.MainDispatcherListener
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+
+@ExperimentalCoroutinesApi
+class UserDetailViewModelSpec : DescribeSpec({
+    extension(MainDispatcherListener())
+
+    val userDetailRepository = mockk<UserDetailRepository>()
+    lateinit var viewModel: UserDetailViewModel
+
+    val userRepos = listOf(
+        UserRepo(
+            name = "RepositoryName1",
+            description = "Description1",
+            language = "Kotlin",
+            star = 1,
+            url = "",
+            isForked = false
+        ),
+        UserRepo(
+            name = "Repository2",
+            description = "Description2",
+            language = "Kotlin",
+            star = 2,
+            url = "",
+            isForked = true
+        ),
+        UserRepo(
+            name = "Repository3",
+            description = "Description3",
+            language = "Kotlin",
+            star = 3,
+            url = "",
+            isForked = false
+        ),
+    )
+    val filteredUserRepos = userRepos.filter { !it.isForked }
+    val userDetail = UserDetail(
+        userName = "user",
+        screenName = "User",
+        avatarUrl = "https://placehold.jp/240x240.png",
+        followers = 8,
+        following = 16,
+        repos = userRepos
+    )
+
+    beforeSpec {
+        viewModel = UserDetailViewModel(userDetailRepository)
+    }
+
+    describe("#loadUserDetail") {
+        val inputUserName = "user"
+        context("response success") {
+            coEvery {
+                userDetailRepository.getUserDetail(inputUserName)
+            } returns userDetail
+
+            viewModel.loadUserDetail(userName = inputUserName)
+
+            it("userDetail should be collect value") {
+                viewModel.uiState shouldBe UserDetailUiState(
+                    userDetail = userDetail,
+                    userRepos = filteredUserRepos,
+                    hasError = false,
+                    isLoading = false,
+                )
+            }
+
+            it("verify getUserDetail") {
+                coVerify(exactly = 1) { userDetailRepository.getUserDetail(inputUserName) }
+            }
+        }
+
+        context("response fail") {
+            coEvery {
+                userDetailRepository.getUserDetail(inputUserName)
+            } throws Exception()
+
+            viewModel.loadUserDetail(inputUserName)
+
+            it("event should be FetchError") {
+                viewModel.uiState shouldBe UserDetailUiState(
+                    userDetail = null,
+                    userRepos = listOf(),
+                    hasError = true,
+                    isLoading = false
+                )
+            }
+
+            it("verify getUserDetail") {
+                coVerify(exactly = 1) { userDetailRepository.getUserDetail(inputUserName) }
+            }
+        }
+    }
+
+    describe("#errorMessageShown") {
+        context("consume event") {
+            viewModel.errorMessageShown()
+
+            it("event should be null") {
+                viewModel.uiState.hasError.shouldBeFalse()
+            }
+        }
+    }
+})

--- a/app/src/test/java/com/example/learningandroidapp/viewmodel/UserDetailViewModelSpec.kt
+++ b/app/src/test/java/com/example/learningandroidapp/viewmodel/UserDetailViewModelSpec.kt
@@ -45,7 +45,6 @@ class UserDetailViewModelSpec : DescribeSpec({
             isForked = false
         ),
     )
-    val filteredUserRepos = userRepos.filter { !it.isForked }
     val userDetail = UserDetail(
         userName = "user",
         screenName = "User",
@@ -54,6 +53,7 @@ class UserDetailViewModelSpec : DescribeSpec({
         following = 16,
         repos = userRepos
     )
+    val filteredUserRepos = userRepos.filter { !it.isForked }
 
     beforeSpec {
         viewModel = UserDetailViewModel(userDetailRepository)
@@ -70,8 +70,14 @@ class UserDetailViewModelSpec : DescribeSpec({
 
             it("userDetail should be collect value") {
                 viewModel.uiState shouldBe UserDetailUiState(
-                    userDetail = userDetail,
-                    userRepos = filteredUserRepos,
+                    userDetail = UserDetail(
+                        userName = "user",
+                        screenName = "User",
+                        avatarUrl = "https://placehold.jp/240x240.png",
+                        followers = 8,
+                        following = 16,
+                        repos = filteredUserRepos
+                    ),
                     hasError = false,
                     isLoading = false,
                 )
@@ -92,7 +98,6 @@ class UserDetailViewModelSpec : DescribeSpec({
             it("event should be FetchError") {
                 viewModel.uiState shouldBe UserDetailUiState(
                     userDetail = null,
-                    userRepos = listOf(),
                     hasError = true,
                     isLoading = false
                 )

--- a/app/src/test/java/com/example/learningandroidapp/viewmodel/UserDetailViewModelSpec.kt
+++ b/app/src/test/java/com/example/learningandroidapp/viewmodel/UserDetailViewModelSpec.kt
@@ -95,7 +95,7 @@ class UserDetailViewModelSpec : DescribeSpec({
 
             viewModel.loadUserDetail(inputUserName)
 
-            it("event should be FetchError") {
+            it("uiState.hasError should be true") {
                 viewModel.uiState shouldBe UserDetailUiState(
                     userDetail = null,
                     hasError = true,

--- a/app/src/test/java/com/example/learningandroidapp/viewmodel/UserSearchViewModelSpec.kt
+++ b/app/src/test/java/com/example/learningandroidapp/viewmodel/UserSearchViewModelSpec.kt
@@ -70,7 +70,7 @@ class UserSearchViewModelSpec : DescribeSpec({
             viewModel.onUserNameChanged(inputUserName)
             viewModel.searchUser()
 
-            it("event should be FetchError") {
+            it("uiState.hasError should be true") {
                 viewModel.uiState shouldBe UserSearchUiState(
                     userName = inputUserName,
                     hasError = true


### PR DESCRIPTION
### 概要
- 検索結果から遷移するユーザ詳細画面の実装
  -  ユニットテストの実装

### 変更点
- UserDetailRepositorySpec: UserDetailRepositoryのユニットテスト
- UserDetailViewModelSpec: UserDetailViewModelのユニットテスト

### テスト実行結果
![image](https://user-images.githubusercontent.com/20397503/186297757-caeb3383-c707-4f42-b2d1-70e8a5f0bdf0.png)
![image](https://user-images.githubusercontent.com/20397503/186297894-f13e7589-e272-407a-9d16-2f9a90bf1021.png)
